### PR TITLE
pinv instead of inv

### DIFF
--- a/src/normalequation.cpp
+++ b/src/normalequation.cpp
@@ -7,17 +7,10 @@ NormalEquation::NormalEquation() : LinearRegression{} { }
 
 vec NormalEquation::solveNormalEquation(const arma::mat& X, const arma::vec& y) const
 {
-    mat X_aug = arma::join_horiz(arma::ones<vec>(X.n_rows), X);
     // normal equation: Theta = (X.t * X)^-1 * (X.t * y)
-    auto multipliedX = X_aug.t() * X_aug;
-    if (det(multipliedX) == 0) {
-        // TODO to be updated. Also when to little examples comparing to features, it also gets here! (should be other exception
-        throw std::invalid_argument{"there is the same feature twice in dataset! "
-                                    "Will cover this case in further development. "
-                                    "For now you need to manually delete one of these features. "
-                                    "(There is no learning gain from it)!"};
-    }
-    return multipliedX.i() * (X_aug.t() * y);
+    // changed approach - moore-penrose pseudo-inverse matrix
+    mat X_aug = arma::join_horiz(arma::ones<vec>(X.n_rows), X);
+    return arma::pinv(X_aug) * y;
 }
 
 void NormalEquation::fit(const arma::mat& X, const arma::vec& y)
@@ -35,4 +28,3 @@ arma::vec NormalEquation::getFitResults(const arma::mat& X, const arma::vec& y) 
 {
     return solveNormalEquation(X,y);
 }
-

--- a/src/stochasticgradientdescent.cpp
+++ b/src/stochasticgradientdescent.cpp
@@ -1,0 +1,3 @@
+#include "stochasticgradientdescent.h"
+
+StochasticGradientDescent::StochasticGradientDescent() {}


### PR DESCRIPTION
Abandoned original approach because of its numeric errors vulnerability in favor of calculating Moore-Penrose pseudo inverse matrix.